### PR TITLE
Updated ProtectedRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,31 @@ react-protected-route
 A ReactJS route component that redirects users trying to access a protected route.
 
 # Example
-The code below assumes `isAuthenticated` is `true`, and will render the protected route.
 ```js
+import React from "react";
+import { Route, Switch } from "react-router-dom";
 import ProtectedRoute from "react-protected-route";
 
-// this can be read from your state which looks at 
+// this can be read from your state which looks at
 // login and/or any logic to protect certain routes.
-const isLoggedIn = false; 
+const isLoggedIn = false;
 
 // Example usage
-const Routes = () => 
+const Routes = () =>
 <Switch>
+    <Route path="/" render={() => <p>Homepage</p>} />
     <ProtectedRoute
-        isAuthenticated={isLoggedIn}
-        redirectTo="/login"
         path="/myaccount"
         component={() => <p>Protected account access</p>}
+        predicate={isLoggedIn} // only show when user is logged in
+        redirectTo="/login" // otherwise redirect to '/login'
     />
-    <Route
+    <ProtectedRoute
         path="/login"
         render={() => <p>Please sign in to access your account.</p>}
+        predicate={!isLoggedIn} // only show when not logged in
+        redirectTo="/" // otherwise redirect to '/'
+        useFrom // unless ProtectedRoute recorded where they came from, then redirect to there
     />
 </Switch>;
 ```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "prop-types": "15.6.2",
     "react": "16.7.0",
-    "react-router-dom": "4.3.1"
+    "react-router-dom": "4.3.1",
+    "render-props": "^1.1.0"
   },
   "peerDependencies": {
     "react": "16.7.0",

--- a/src/ProtectedRoute.js
+++ b/src/ProtectedRoute.js
@@ -1,24 +1,47 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import renderProps from 'render-props';
 
-class ProtectedRoute extends Component {
-    static propTypes = {
-        isAuthenticated: PropTypes.bool,
-        redirectTo: PropTypes.string,
-        component: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-    };
-
-    static defaultProps = {
-        isAuthenticated: false,
-        redirectTo: '/'
-    };
-
-    render() {
-        const { isAuthenticated, redirectTo, component: ProtectedComponent, ...rest } = this.props;
-
-        return <Route {...rest} render={props => (isAuthenticated ? <ProtectedComponent {...props} /> : <Redirect to={redirectTo} />)} />;
-    }
+export default function ProtectedRoute({
+  predicate,
+  redirectTo,
+  component,
+  render,
+  children,
+  useFrom,
+  ...rest
+}) {
+  return (
+    <Route
+      {...rest}
+      render={props => {
+        if (predicate) {
+          if (React.isValidElement(children)) return children;
+          else return renderProps(component || children || render, props);
+        } else {
+          const { state } = props.history.location;
+          const newLocation = {
+            pathname: redirectTo,
+            ...(useFrom && state && state.from),
+            state: { from: props.location },
+          };
+          return <Redirect to={newLocation} />;
+        }
+      }}
+    />
+  );
 }
-
-export default ProtectedRoute;
+ProtectedRoute.propTypes = {
+  predicate: PropTypes.bool,
+  redirectTo: PropTypes.string,
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  render: PropTypes.func,
+  useFrom: PropTypes.bool,
+};
+ProtectedRoute.defaultProps = {
+  predicate: false,
+  redirectTo: '/',
+  useFrom: false,
+};


### PR DESCRIPTION
- Fixes: #1 Allowing redirect to recorded from state
- Fixes: #2 Supports render prop
- Supports  children as component
- Using less specific `predicate` instead of `isAuthenticated`

I realize this changes more than what 1 PR should, I'd be happy to split if up in separate ones.
I've also updated my example: https://github.com/peteruithoven/protected-route-example

And thanks for the invite to collaborate!